### PR TITLE
Dev metadata

### DIFF
--- a/read_acq/__init__.py
+++ b/read_acq/__init__.py
@@ -317,11 +317,13 @@ def decode_file(
             Qratio=Q.T,
             time_data=anc.data,
             freqs=anc.frequencies,
+            fastspec_version=anc.fastspec_version,
+            size=anc.size,
             **{"p{}".format(i): p[i].T for i in range(3)},
         )
 
     if meta:
-        return Q, p, anc.meta
+        return Q, p, anc
     else:
         return Q, p
 

--- a/read_acq/__init__.py
+++ b/read_acq/__init__.py
@@ -217,7 +217,7 @@ class Ancillary:
 
 def decode_file(
     fname, outfile=None, write_formats=None, progress=True,
-meta=False):
+        meta=False):
     """
     Parse and decode an ACQ file, optionally writing it to a new format.
 
@@ -319,8 +319,8 @@ meta=False):
             freqs=anc.frequencies,
             **{"p{}".format(i): p[i].T for i in range(3)},
         )
-    
-    if meta==True:
+
+    if meta:
         return Q, p, anc.meta
     else:
         return Q, p

--- a/read_acq/__init__.py
+++ b/read_acq/__init__.py
@@ -217,7 +217,7 @@ class Ancillary:
 
 def decode_file(
     fname, outfile=None, write_formats=None, progress=True,
-):
+meta=False):
     """
     Parse and decode an ACQ file, optionally writing it to a new format.
 
@@ -239,6 +239,8 @@ def decode_file(
         Can contain any of 'mat' and 'npz'.
     progress: bool, optional
         Whether to display a progress bar for the read.
+    meta: bool, optional
+        Whether to output metadata for the read.
     """
     for fmt in write_formats:
         if fmt not in writers._WRITERS:
@@ -317,8 +319,11 @@ def decode_file(
             freqs=anc.frequencies,
             **{"p{}".format(i): p[i].T for i in range(3)},
         )
-
-    return Q, p
+    
+    if meta==True:
+        return Q, p, anc.meta
+    else:
+        return Q, p
 
 
 def decode_files(files, *args, **kwargs):


### PR DESCRIPTION
Added option for decode_file to return file metadata based on Ancillary class, defaults to not return it (so nothing breaks).