### PR TITLE
Fix default writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,46 @@
 # Changelog
 
-# 0.3.2
-## Fixed
+## dev
+### Changed
+- `decode_file` now only decodes the file, rather than writing. Use `convert_file` to
+  convert a file to a different format.
+
+## 0.3.2
+### Fixed
 - Errors in writing out files (now have tests)
 
-# 0.3.1
+## 0.3.1
 
-## Fixed
+### Fixed
 - Error reading fastspec header due to first VERSION line.
 
-# 0.3.0 [27.Dec.2019]
+## 0.3.0 [27.Dec.2019]
 
-## Added
+### Added
 - Ability to read in new fastspec header
 - New format: npz
 - Ability to save all metadata
 
-## Changed
+### Changed
 - Structure of the code is now class-based and extendible
 - **No longer outputs uncalibrated temperature, but rather the dimensionless ratio, Q**
 
-## Fixed
+### Fixed
 - Line-incrementing problem when reading
 
 
-# 0.2.0
+## 0.2.0
 
-## Added
+### Added
 - HDF5 output format
 - Ability to specify output format via CLI
 - Metadata to outputs
 
-## Fixed
+### Fixed
 - Removed warnings when dividing by zero
 - Installation without numpy
 - Progress bar iterations
 
-# 0.1.0
+## 0.1.0
 
 - Initial version that reads ACQ into memory.

--- a/src/read_acq/__init__.py
+++ b/src/read_acq/__init__.py
@@ -1,5 +1,12 @@
 from pkg_resources import get_distribution, DistributionNotFound
-from .read_acq import Ancillary, decode_files, decode_file, encode, convert_h5
+from .read_acq import (
+    Ancillary,
+    decode_files,
+    decode_file,
+    encode,
+    convert_h5,
+    convert_file,
+)
 from . import writers
 from . import codec
 

--- a/src/read_acq/cli.py
+++ b/src/read_acq/cli.py
@@ -12,8 +12,9 @@ from __future__ import print_function
 import glob
 
 import click
+import tqdm
 
-from . import decode_files
+from . import convert_file
 
 main = click.Group()
 
@@ -30,11 +31,7 @@ main = click.Group()
     type=click.Path(exists=False, dir_okay=False),
 )
 @click.option(
-    "-f",
-    "--format",
-    default=("mat",),
-    multiple=True,
-    type=click.Choice(["mat", "h5", "npz"]),
+    "-f", "--format", default="h5", type=click.Choice(["h5", "mat", "npz"]),
 )
 def convert(infile, outfile, format):
     fls = []
@@ -42,4 +39,7 @@ def convert(infile, outfile, format):
         fls += glob.glob(fl)
     fls = list(set(fls))
 
-    decode_files(fls, outfile=outfile, write_formats=format)
+    for fl in tqdm.tqdm(
+        fls, disable=len(fls) < 5, desc="Processing files", unit="files"
+    ):
+        convert_file(fl, outfile=outfile, write_format=format)

--- a/src/read_acq/cli.py
+++ b/src/read_acq/cli.py
@@ -31,7 +31,10 @@ main = click.Group()
     type=click.Path(exists=False, dir_okay=False),
 )
 @click.option(
-    "-f", "--format", default="h5", type=click.Choice(["h5", "mat", "npz"]),
+    "-f",
+    "--format",
+    default="h5",
+    type=click.Choice(["h5", "mat", "npz"]),
 )
 def convert(infile, outfile, format):
     fls = []

--- a/src/read_acq/read_acq.py
+++ b/src/read_acq/read_acq.py
@@ -205,8 +205,6 @@ class Ancillary:
 
 def decode_file(
     fname,
-    outfile=None,
-    write_formats=None,
     progress=True,
     meta=False,
     leave_progress=True,
@@ -218,10 +216,7 @@ def decode_file(
     ----------
     fname : str or Path
         filename of the ACQ file to read.
-    outfile: str, optional
-        Filename to which to write the data. Only used if `write_formats` is not empty.
-    write_formats: list of str, optional
-        Can contain any of 'mat', 'h5' and 'npz'. Default is 'h5'.
+
     progress: bool, optional
         Whether to display a progress bar for the read.
     meta: bool, optional
@@ -230,12 +225,6 @@ def decode_file(
         Whether to leave the progress bar (if one is used) on the screen when done.
         Useful to set to False if reading multiple files.
     """
-    for fmt in write_formats:
-        if fmt not in writers._WRITERS:
-            raise ValueError(
-                "The format {} does not have an associated writer.".format(fmt)
-            )
-
     anc = Ancillary(fname)
     n_times = anc.size
 
@@ -334,6 +323,11 @@ def convert_file(
     All other parameters passed through to :func:`decode_file`.
     """
     kwargs["meta"] = True
+    if write_format not in writers._WRITERS:
+        raise ValueError(
+            f"The format '{write_format}' does not have an associated writer."
+        )
+
     Q, p, anc = decode_file(fname, **kwargs)
 
     getattr(writers, f"_write_{write_format}")(
@@ -346,6 +340,7 @@ def convert_file(
         size=anc.size,
         **{f"p{i}": p[i] for i in range(3)},
     )
+    return Q, p, anc
 
 
 def encode(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+from click.testing import CliRunner
+from read_acq.cli import convert
+from pathlib import Path
+import h5py
+from read_acq import decode_file
+import numpy as np
+
+
+def test_convert(tmp_path_factory):
+    cli = CliRunner()
+
+    data = Path(__file__).parent / "data/sample.acq"
+    outfile = tmp_path_factory.mktemp("direc") / "tempfile.h5"
+
+    result = cli.invoke(
+        convert, [str(data), "--outfile", str(outfile), "--format", "h5"]
+    )
+    assert result.exit_code == 0
+    print(result.output)
+
+    Q, p, meta = decode_file(data, meta=True)
+
+    with h5py.File(outfile, "r") as fl:
+        qq = fl["spectra"]["Q"][...]
+
+    assert np.allclose(qq[~np.isnan(qq)], Q[~np.isnan(Q)])

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from read_acq import decode_file
+from read_acq import convert_file
 import h5py
 import numpy as np
 from scipy.io import loadmat
@@ -9,7 +9,7 @@ def test_h5(tmp_path_factory):
     data = Path(__file__).parent / "data/sample.acq"
 
     outfile = tmp_path_factory.mktemp("direc") / "tempfile.h5"
-    Q, p, meta = decode_file(data, outfile=outfile, write_formats=["h5"], meta=True)
+    Q, p, meta = convert_file(data, outfile=outfile, write_format="h5", meta=True)
 
     with h5py.File(outfile, "r") as fl:
         qq = fl["spectra"]["Q"][...]
@@ -20,9 +20,9 @@ def test_h5(tmp_path_factory):
 def test_mat(tmp_path_factory):
     data = Path(__file__).parent / "data/sample.acq"
     outfile = tmp_path_factory.mktemp("direc") / "tempfile.mat"
-    Q, p, meta = decode_file(data, outfile=outfile, write_formats=["mat"], meta=True)
+    Q, p, meta = convert_file(data, outfile=outfile, write_format="mat", meta=True)
 
-    matdata = loadmat(outfile)
+    matdata = loadmat(str(outfile))
 
     assert np.allclose(matdata["Qratio"][~np.isnan(Q)], Q[~np.isnan(Q)])
 
@@ -30,7 +30,7 @@ def test_mat(tmp_path_factory):
 def test_npz(tmp_path_factory):
     data = Path(__file__).parent / "data/sample.acq"
     outfile = tmp_path_factory.mktemp("direc") / "tempfile.npz"
-    Q, p, meta = decode_file(data, outfile=outfile, write_formats=["npz"], meta=True)
+    Q, p, meta = convert_file(data, outfile=outfile, write_format="npz", meta=True)
 
     matdata = np.load(outfile)
 


### PR DESCRIPTION
Fixes #11 

Changes default writer to h5, and makes `decode_file` more simple, removing its writing ability.