### PR TITLE
ci: don't use PSR

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,29 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+source = read_acq
+parallel = True
+# omit = bad_file.py
+
+[paths]
+source =
+    src/
+    */site-packages/
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,51 +5,55 @@ on:
       - main
 
 jobs:
-  release:
+  bump-version:
+    name: SemVer Bump
     runs-on: ubuntu-latest
     outputs:
-      run_rest_jobs: ${{ steps.semrel.outputs.dist_made }}
+      new_version: ${{ steps.bump.outputs.new_version }}
+      new_tag: ${{ steps.bump.outputs.new_tag }}
+      previous_tag: ${{ steps.bump.outputs.previous_tag }}
+      previous_version: ${{ steps.bump.outputs.previous_version }}
+      release_type: ${{ steps.bump.outputs.release_type }}
+      changelog: ${{ steps.bump.outputs.changelog }}
+
     steps:
-      # Step 2. Set up Python 3.9
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      # Step 3. Check-out repository so we can access its contents
       - uses: actions/checkout@v2
+        # Ensure full history is gotten.
         with:
           fetch-depth: 0
-      # Step 4. Use PSR to make release
-      - name: Python Semantic Release
-        id: semrel
-        run: |
-            pip install python-semantic-release
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            semantic-release publish
-            if [ "$(ls -A dist)" ]; then
-              echo "::set-output name=dist_made::true"
-            else
-              echo "::set-output name=dist_made::false"
-            fi
+      - name: Get New Version
+        id: bump
+        uses: mathieudutour/github-tag-action@v6
+        with:
+          default_bump: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
 
   deploy:
-    needs: [release]
-    if: needs.release.outputs.run_rest_jobs == 'true'
+    name: Deploy
     runs-on: ubuntu-latest
+    needs: bump-version
+    if: needs.bump-version.outputs.new_version != null
     steps:
-      # Step 5. Publish to TestPyPI
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@master
+      # https://github.com/ansible/pylibssh/blob/1e7b17f/.github/workflows/build-test-n-publish.yml#L146-L151
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          password: ${{ secrets.tes_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
-      # Step 6. Test install from TestPyPI
-      - name: Test install from TestPyPI
+          python-version: 3.x
+      - name: Create setuptools_scm env variable
+        shell: bash
         run: |
-            pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --extra-index-url https://pypi.org/simple \
-            read_acq
-      # Step 7. Publish to PyPI
-      - uses: pypa/gh-action-pypi-publish@release/v1
+          version=${{ needs.bump-version.outputs.new_version }}
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$version" >> $GITHUB_ENV
+      - name: Install build
+        run: |
+          python -m pip install build
+          python -m pip install setuptools_scm
+          python setup.py --version
+      - name: Build a binary wheel and a source tarball
+        run: python -m build
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.PYPI_PASSWORD }}
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -2,14 +2,11 @@ name: Tests
 
 # Test on all pushes, except when the push is literally just a tag (because we
 # tag automatically via CI, and therefore there's no extra code in that push).
-# Also, only test on pull requests into master.
 on:
   push:
     tags-ignore:
       - 'v*'
   pull_request:
-    branches:
-      - 'main'
 
 jobs:
   tests:
@@ -23,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -39,9 +36,49 @@ jobs:
           pip install .[dev]
       - name: Run Tests
         run: |
-          python -m pytest --cov=read_acq --cov-config=.coveragerc --cov-report xml:./coverage.xml --durations=25
-      - uses: codecov/codecov-action@master
-        if: matrix.os == 'ubuntu-latest' && success()
+          python -m pytest --cov-config=.coveragerc --durations=25
+  downstream:
+    env:
+      PYTHON: 3.8
+      OS: ubuntu-latest
+    name: Downstream
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ['edges-io', 'edges-cal','edges-analysis']
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@master
         with:
-          token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./coverage.xml #optional
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON }}
+      - name: set PY
+        run: echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
+      - name: Setup Environment
+        run: |
+          pip install -U coverage
+          pip install .[dev]
+      - name: Get downstream package
+        run: |
+          cd ..
+          git clone https://github.com/edges-collab/${{ matrix.package }}
+          cd ${{ matrix.package }}
+          pip install .[dev]
+      - name: Install ipykernel
+        if: matrix.package == 'edges-cal'
+        run: python -m ipykernel install --user --name edges --display-name "edges"
+      - name: Print Versions
+        run: pip freeze | grep "edges-"
+      - name: Run Tests
+        run: |
+          cd ../${{ matrix.package }}
+          python -m pytest --cov-config=../read_acq/.coveragerc
+
+  codecov:
+    needs: [downstream, tests]
+    name: Codecov Reporting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codecov/codecov-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,3 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-
-
-
-[tool.semantic_release]
-version_source = "tag"
-branch = "main"                             # branch to make releases of
-changelog_file = "CHANGELOG.md"             # changelog file
-build_command = "python -m pip install build && python -m build --sdist"
-dist_path = "dist/"                         # where to put dists
-upload_to_pypi = false                      # don't auto-upload to PyPI
-remove_dist = false                         # don't remove dists


### PR DESCRIPTION
Go back to using plain github-tag-action to do the publishing. Still have to figure out a way to update the changelog. Probably something like just changing a `dev version` in the changelog to the new version would suffice.