### PR TITLE
fix: ability to continue when spectrum line is deformed/incomplete

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,6 +25,6 @@ jobs:
           python -m build -s .
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.8.8
+        uses: pypa/gh-action-pypi-publish@v1.8.8
         with:
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This should enable the reader to keep running when it encounters a line with an incomplete spectrum