### PR TITLE
ci: pin downstream test deps to edges-analysis's lockfile

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -72,6 +72,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON }}
+      - uses: astral-sh/setup-uv@v7
       - name: set PY
         run: echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
       - name: Setup Environment
@@ -83,7 +84,15 @@ jobs:
           cd ..
           git clone https://github.com/edges-collab/${{ matrix.package }}
           cd ${{ matrix.package }}
-          pip install --group dev .
+          # Constrain to the exact versions in the downstream package's own
+          # uv.lock (what its own CI verifies works), instead of letting pip
+          # resolve arbitrary latest versions of its test dependencies. This
+          # avoids spurious downstream failures when a transitive test
+          # dependency (e.g. pytest_cases) publishes a release that's
+          # incompatible with the latest pytest. See
+          # https://github.com/smarie/python-pytest-cases/issues/385
+          uv export --locked --all-groups --no-hashes --no-emit-project --no-emit-workspace -o /tmp/downstream-constraints.txt
+          pip install --group dev . -c /tmp/downstream-constraints.txt
       - name: Print Versions
         run: pip freeze | grep -E "edges-|read_acq"
 


### PR DESCRIPTION
## Summary
- Fixes the failing `Tests / Downstream (edges-analysis)` check (see [PR #148](https://github.com/edges-collab/read_acq/pull/148), which is unrelated pre-commit.ci bumps but has this check red).
- The downstream job cloned `edges-analysis` and ran a plain `pip install --group dev .`, which resolves the newest `pytest` on PyPI (9.1.1) rather than the pinned, known-good versions in edges-analysis's own `uv.lock` (`pytest==9.0.3`, `pytest-cases==3.9.1`).
- `pytest` 9.1.x has a known, still-open upstream incompatibility with `pytest_cases` ([smarie/python-pytest-cases#385](https://github.com/smarie/python-pytest-cases/issues/385)), which surfaces as `TypeError: IdMaker.__init__() takes 7 positional arguments but 8 were given` during collection.
- edges-analysis's own CI never hits this because it runs `uv sync --locked`. This PR makes the downstream job do the equivalent: export edges-analysis's lockfile via `uv export` and pass it to `pip install` as a constraints file, so the resolved versions match what edges-analysis's own CI has already verified.
- No changes needed in edges-analysis — this was purely a gap in read_acq's downstream CI dependency resolution, not a bug in either package's source.

## Test plan
- [x] Reproduced locally: unconstrained `pip install --group dev .` for a fresh edges-analysis clone pulls `pytest==9.1.1`, and pytest collection fails with the `IdMaker` `TypeError`.
- [x] With the fix applied (`uv export --locked ... | pip install -c constraints.txt`), the install resolves to `pytest==9.0.3` / `pytest-cases==3.9.1`, and the `IdMaker` error is gone.
- [ ] Confirm the `Tests / Downstream (edges-analysis)` check goes green on this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)